### PR TITLE
feat: add `MethodURLError` and non-throwing `tryurl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Supported git forges: GitHub, GitLab (including self-hosted instances), sourcehu
 
 If no URL can be constructed, `url` throws a `MethodURLError`.
 Its `reason` field identifies the cause of the failure, e.g. `:no_package_dir` for methods that do not belong to a package, such as methods defined in the REPL.
-The non-throwing variant `tryurl` returns the `MethodURLError` instead of throwing it:
+The non-throwing variant `tryurl` returns the `MethodURLError` instead of throwing it.
+In the following example, the queried method is that of an anonymous function defined in the REPL,
+which belongs to the module `Main` rather than any package, so there is no source repository to link to:
 
 ```julia
 julia> MethodURL.tryurl(methods(x -> x^2)[1])

--- a/README.md
+++ b/README.md
@@ -31,7 +31,15 @@ URLs are constructed according to the origin of the method:
   One URL is returned per registry the package is found in.
 
 Supported git forges: GitHub, GitLab (including self-hosted instances), sourcehut, Bitbucket and Codeberg.
-An error is thrown if no URL can be constructed.
+
+If no URL can be constructed, `url` throws a `MethodURLError`.
+Its `reason` field identifies the cause of the failure, e.g. `:no_package_dir` for methods that do not belong to a package, such as methods defined in the REPL.
+The non-throwing variant `tryurl` returns the `MethodURLError` instead of throwing it:
+
+```julia
+julia> MethodURL.tryurl(methods(x -> x^2)[1])
+MethodURLError(:no_package_dir, "Failed to find package directory of module Main.")
+```
 
 Note that a constructed URL can still point to a non-existent page,
 e.g. if a package release was never tagged in its repository.

--- a/src/MethodURL.jl
+++ b/src/MethodURL.jl
@@ -16,9 +16,38 @@ using Base:
 using RegistryInstances: reachable_registries, registry_info
 using Downloads: request, Response
 
-export url
+export url, tryurl, MethodURLError
 
 const JULIA_REPO = "https://github.com/JuliaLang/julia"
+
+"""
+    MethodURLError(reason::Symbol, msg::String)
+
+Error thrown by [`url`](@ref) and returned by [`tryurl`](@ref)
+when no URL can be constructed for a method.
+
+The `reason` field identifies the cause of the failure:
+- `:no_package_dir`: the parent module does not belong to a package,
+  e.g. for methods defined in the REPL, a notebook or a script
+- `:no_project`: the package directory contains no Project.toml with a name and UUID
+- `:file_not_found`: the method's file is not part of the package,
+  e.g. for methods evaluated from strings
+- `:no_version`: the version of the package could not be determined
+- `:unknown_forge`: the repository is hosted on an unsupported git forge
+- `:package_not_found`: the package is not listed in any manifest or registry
+  and is not a stdlib
+- `:network`: fetching a stdlib version file from the JuliaLang/julia repository failed,
+  e.g. when offline
+- `:parse`: a fetched stdlib version file could not be parsed
+
+The `msg` field contains a human-readable description of the failure.
+"""
+struct MethodURLError <: Exception
+    reason::Symbol
+    msg::String
+end
+
+Base.showerror(io::IO, e::MethodURLError) = print(io, "MethodURLError: ", e.msg)
 
 """
     url(m::Method)
@@ -43,9 +72,42 @@ Constructing stdlib URLs requires fetching a `<name>.version` file from the
 JuliaLang/julia repository, so calling `url` on stdlib methods can access the
 network. The result of this lookup is cached for the lifetime of the session.
 
-Throw an error if no URL can be constructed.
+Throw a [`MethodURLError`](@ref) if no URL can be constructed.
+See [`tryurl`](@ref) for a non-throwing variant.
 """
 function url(m::Method)
+    result = tryurl(m)
+    result isa MethodURLError && throw(result)
+    return result
+end
+
+"""
+    tryurl(m::Method)
+
+Like [`url`](@ref), but return a [`MethodURLError`](@ref) instead of throwing it
+when no URL can be constructed.
+
+The `reason` field of the returned error allows handling failure causes
+programmatically, e.g. ignoring methods that do not belong to a package:
+
+```julia
+result = tryurl(m)
+if result isa Vector{String}
+    # use the URLs
+elseif result.reason !== :no_package_dir
+    @warn result.msg
+end
+```
+"""
+function tryurl(m::Method)
+    return try
+        _url(m)
+    catch e
+        e isa MethodURLError ? e : rethrow()
+    end
+end
+
+function _url(m::Method)
     M = parentmodule(m)
     file = fixup_stdlib_path(String(m.file))
     line = m.line
@@ -94,7 +156,8 @@ function url(m::Method)
     end
 
     throw(
-        ArgumentError(
+        MethodURLError(
+            :package_not_found,
             "Failed to construct URL for method `$m`: " *
                 "package $name [$uuid] was not found in any manifest, registry, or the stdlib.",
         ),
@@ -138,7 +201,12 @@ function forge_url(
         segment = kind === :tag ? "tag" : kind === :commit ? "commit" : "branch"
         return "$repo/src/$segment/$ref/$path#L$line"
     else
-        throw(ArgumentError("Failed to construct URL for unknown git forge of repository $repo."))
+        throw(
+            MethodURLError(
+                :unknown_forge,
+                "Failed to construct URL for unknown git forge of repository $repo.",
+            ),
+        )
     end
 end
 
@@ -152,7 +220,11 @@ end
 # (also before Windows drive letters) and percent-encoded spaces.
 function file_url(file::AbstractString, line::Integer)
     if !isabspath(file)
-        throw(ArgumentError("Failed to construct URL: $file is not an absolute file path."))
+        throw(
+            MethodURLError(
+                :file_not_found, "Failed to construct URL: $file is not an absolute file path."
+            ),
+        )
     end
     path = replace(file, '\\' => '/', ' ' => "%20")
     if !startswith(path, "/")
@@ -166,7 +238,12 @@ end
 function path_in_package(dir::AbstractString, file::AbstractString)
     parts = splitpath(relpath(file, dir))
     if !isabspath(file) || first(parts) == ".."
-        throw(ArgumentError("Failed to construct URL: file $file is not part of the package at $dir."))
+        throw(
+            MethodURLError(
+                :file_not_found,
+                "Failed to construct URL: file $file is not part of the package at $dir.",
+            ),
+        )
     end
     return join(parts, "/")
 end
@@ -196,14 +273,16 @@ end
 # Like `pkgdir`, but throws instead of returning `nothing`
 function _pkgdir(M::Module)
     dir = pkgdir(M)
-    isnothing(dir) && throw(ArgumentError("Failed to find package directory of module $M."))
+    isnothing(dir) &&
+        throw(MethodURLError(:no_package_dir, "Failed to find package directory of module $M."))
     return dir
 end
 
 # Like `pkgversion`, but throws instead of returning `nothing`
 function _pkgversion(M::Module)
     version = pkgversion(M)
-    isnothing(version) && throw(ArgumentError("Failed to find version of package $M."))
+    isnothing(version) &&
+        throw(MethodURLError(:no_version, "Failed to find version of package $M."))
     return version
 end
 
@@ -221,7 +300,7 @@ function project_name_uuid(dir::AbstractString)
             return name, UUID(uuid)
         end
     end
-    throw(ArgumentError("Failed to find name and UUID of the package at $dir."))
+    throw(MethodURLError(:no_project, "Failed to find name and UUID of the package at $dir."))
 end
 
 # Manifest entry of the package `uuid`, searched through all environments
@@ -323,16 +402,29 @@ function fetch_stdlib_repo_and_sha(name::AbstractString)
     version_url = "https://raw.githubusercontent.com/JuliaLang/julia/$(julia_ref())/stdlib/$name.version"
     buffer = IOBuffer()
     response = request(version_url; output = buffer, throw = false)
-    response isa Response || throw(response) # RequestError, e.g. when offline
+    if !(response isa Response) # RequestError, e.g. when offline
+        throw(
+            MethodURLError(
+                :network,
+                "Failed to fetch stdlib version file at $version_url: " *
+                    sprint(showerror, response),
+            ),
+        )
+    end
     response.status == 404 && return nothing # stdlib source is part of the julia repository
     if response.status != 200
-        error("Failed to fetch stdlib version file at $version_url (HTTP status $(response.status)).")
+        throw(
+            MethodURLError(
+                :network,
+                "Failed to fetch stdlib version file at $version_url (HTTP status $(response.status)).",
+            ),
+        )
     end
     content = String(take!(buffer))
     sha = match(r"_SHA1\s*:?=\s*([0-9a-f]{40})", content)
     repo = match(r"_GIT_URL\s*:?=\s*(\S+)", content)
     if isnothing(sha) || isnothing(repo)
-        error("Failed to parse stdlib version file at $version_url.")
+        throw(MethodURLError(:parse, "Failed to parse stdlib version file at $version_url."))
     end
     return (String(something(repo[1])), String(something(sha[1])))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -297,11 +297,18 @@ end
             @testset "Method defined in Main" begin
                 f_in_main() = 1
                 m = first(methods(f_in_main))
-                @test_throws ArgumentError url(m)
+                @test_throws MethodURLError url(m)
+                e = @inferred Union{Vector{String}, MethodURLError} tryurl(m)
+                @test e isa MethodURLError
+                @test e.reason === :no_package_dir
+                @test contains(sprint(showerror, e), "MethodURLError: Failed to find")
             end
             @testset "Anonymous function defined in Main" begin
                 m = first(methods(x -> x^2))
-                @test_throws ArgumentError url(m)
+                @test_throws MethodURLError url(m)
+                e = tryurl(m)
+                @test e isa MethodURLError
+                @test e.reason === :no_package_dir
             end
             @testset "Method eval'd into a package" begin
                 # Parsing from a string gives the method the file "none",
@@ -309,12 +316,21 @@ end
                 Core.eval(MethodURL, Meta.parse("__dummy_method_for_testing() = 1"))
                 m = first(methods(MethodURL.__dummy_method_for_testing))
                 @test m.file === :none
-                @test_throws ArgumentError url(m)
+                @test_throws MethodURLError url(m)
+                e = tryurl(m)
+                @test e isa MethodURLError
+                @test e.reason === :file_not_found
             end
             @testset "Unknown git forge" begin
-                @test_throws ArgumentError MethodURL.forge_url(
+                @test_throws MethodURLError MethodURL.forge_url(
                     "https://example.com/owner/Package.jl.git", "v1.0.0", :tag, "src/foo.jl", 1
                 )
+            end
+            @testset "tryurl on a registered package" begin
+                m = @which Aqua.test_all(MethodURL)
+                result = @inferred Union{Vector{String}, MethodURLError} tryurl(m)
+                @test result isa Vector{String}
+                @test result == url(m)
             end
         end
 
@@ -330,7 +346,7 @@ end
                     "file:///C:/Users/u/pkg/src/foo.jl#L3"
             end
             # Relative paths cannot be turned into file URLs
-            @test_throws ArgumentError MethodURL.file_url("none", 1)
+            @test_throws MethodURLError MethodURL.file_url("none", 1)
         end
 
         @testset "URL construction for git forges" begin


### PR DESCRIPTION
Consumers like Pluto want to handle failures as values instead of catching exceptions, e.g. to skip the source link for methods defined in a notebook. `tryurl` returns a `MethodURLError` instead of throwing it, following the `parse`/`tryparse` convention.

- `MethodURLError` carries a machine-checkable `reason` field (`:no_package_dir`, `:file_not_found`, `:network`, ...) so failure causes can be distinguished without string-matching messages
- `url` now throws `MethodURLError` instead of `ArgumentError` and is implemented on top of `tryurl`
- network failures while fetching stdlib version files are wrapped in `MethodURLError(:network, ...)` instead of leaking a raw `Downloads.RequestError`